### PR TITLE
refactor: Use split once in renamer

### DIFF
--- a/src/provider_handle.rs
+++ b/src/provider_handle.rs
@@ -28,7 +28,10 @@ impl ProviderHandle {
         let options = args
             .provider_options
             .iter()
-            .map(|o| split_eq(o).unwrap())
+            .map(|o| {
+                let (s1, s2) = split_eq(o).unwrap();
+                (s1.to_owned(), s2.to_owned())
+            })
             .collect();
 
         let provider = args.provider.clone();

--- a/src/renamers.rs
+++ b/src/renamers.rs
@@ -16,9 +16,14 @@ struct RenameParam {
 impl RenameParam {
     pub fn build(s: &str) -> Result<RenameParam, Box<dyn Error>> {
         let (lhs, rhs) = split_eq(s)?;
-        let (p1, t1) = split___(lhs.as_str());
-        let (p2, t2) = split___(rhs.as_str());
-        Ok(RenameParam { p1, p2, t1, t2 })
+        let (p1, t1) = split___(lhs);
+        let (p2, t2) = split___(rhs);
+        Ok(RenameParam {
+            p1: p1.to_owned(),
+            p2: p2.to_owned(),
+            t1: t1.to_owned(),
+            t2: t2.to_owned(),
+        })
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,24 +2,15 @@ use chrono::{DateTime, Months, TimeDelta, Utc};
 
 use crate::errors::SplitError;
 
-pub fn split___(s: &str) -> (String, String) {
-    let s: Vec<&str> = s.split("___").collect();
-    if s.len() == 1 {
-        (s[0].to_string(), String::new())
-    } else {
-        (s[0].to_string(), s[1].to_string())
-    }
+pub fn split___(s: &str) -> (&str, &str) {
+    s.split_once("___").unwrap_or((s, ""))
 }
 
-pub fn split_eq(s: &str) -> Result<(String, String), SplitError> {
-    let split: Vec<&str> = s.split("=").collect();
-    match split.len() {
-        2 => Ok((split[0].to_string(), split[1].to_string())),
-        _ => Err(SplitError {
-            field: s.to_string(),
-            reason: String::from("field should contain one and only one (key=value)"),
-        }),
-    }
+pub fn split_eq(s: &str) -> Result<(&str, &str), SplitError> {
+    s.split_once('=').ok_or_else(|| SplitError {
+        field: s.to_string(),
+        reason: String::from("field should contain one `=` (key=value)"),
+    })
 }
 
 pub fn end_of_month(date: &DateTime<Utc>) -> DateTime<Utc> {


### PR DESCRIPTION
This also enables the use of equals inside values. Eg: `-p url="http://example.com/?type=ics"`